### PR TITLE
增加可自定义的随机文章头图（Post Image）列表

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -66,7 +66,7 @@ gray:
 
 # Post image
 post_image:
-  random: true # need to turn on galleries
+  random: local #gallery
   default: /images/theme/post-image.jpg
 
 # Donate

--- a/_example/source/_data/local_image.json
+++ b/_example/source/_data/local_image.json
@@ -1,0 +1,19 @@
+[{
+  "photos": [
+    "https://pic.izhaoo.com/2014031601.jpg",
+    "https://pic.izhaoo.com/2017071602.jpg",
+    "https://pic.izhaoo.com/2017071603.jpg",
+    "https://pic.izhaoo.com/2017072104.jpg",
+    "https://pic.izhaoo.com/2017072705.jpg",
+    "https://pic.izhaoo.com/20200421201200.jpg",
+    "https://pic.izhaoo.com/20200305030152.jpg",
+    "https://pic.izhaoo.com/20191211065241.jpg",
+    "https://pic.izhaoo.com/20200228081718.jpg",
+    "https://pic.izhaoo.com/20191211065844.jpg",
+    "https://pic.izhaoo.com/20200718151924.jpg",
+    "https://pic.izhaoo.com/20200718152003.jpg",
+    "https://pic.izhaoo.com/20200718152045.jpg",
+    "https://pic.izhaoo.com/20200718152122.jpg",
+    "https://pic.izhaoo.com/20200718151427.jpg"
+  ]
+}]

--- a/scripts/random-image.js
+++ b/scripts/random-image.js
@@ -5,8 +5,18 @@ module.exports.randomImage = function (hexo) {
     var config = hexo.theme.config;
     var data = hexo.locals.get('data');
     var res = config.post_image.default;
-    if (config.post_image.random && data.galleries) {
+    if (config.post_image.random == 'gallery' && data.galleries) {
       var galleries = data.galleries;
+      var images = [];
+      for (var item of galleries) {
+        item.photos.forEach(function (item) {
+          images.push(item);
+        });
+      }
+      var count = images.length;
+      res = images[Math.floor(Math.random() * count)];
+    } else if (config.post_image.random == 'local' && data.local_image) {
+      var galleries = data.local_image;
       var images = [];
       for (var item of galleries) {
         item.photos.forEach(function (item) {


### PR DESCRIPTION
使用方法：

在 `theme/_config.yml` 主题配置文件中：
```yaml
post_image:
  random: local #gallery
  default: your-default-img-url

```
`local` 表示使用自定义的头图列表，`gallery` 表示使用相册的列表，其他项表示使用 `default`

---

在 `hexo/source/_data/` 中：
创建 `local_image.json` 并写入以下内容：
```json
[{
  "photos": [
    "your-image-url",
    "your-image-url",
    "your-image-url",
    "your-image-url",
  ]
}]
```
将 `your-image-url` 替换为自己的图片链接。

示例 见`_example/source/_data/local_image.json`

---

本机测试通过，不知道能不能行